### PR TITLE
Rtlamr update

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 # MIT License
 
-Copyright (c) 2021-2022 Mike Degatano
+Copyright (c) 2021-2025 Mike Degatano
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -56,27 +56,7 @@ check [the contributor's page][contributors].
 
 ## License
 
-MIT License
-
-Copyright (c) 2021 mdegat01
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+See [LICENSE](LICENSE).
 
 [aarch64-shield]: https://img.shields.io/badge/aarch64-yes-green.svg
 [add-addon-shield]: https://my.home-assistant.io/badges/supervisor_addon.svg

--- a/amr2mqtt/Dockerfile
+++ b/amr2mqtt/Dockerfile
@@ -1,29 +1,14 @@
-ARG BUILD_FROM=ghcr.io/hassio-addons/debian-base/amd64
+ARG BUILD_FROM=ghcr.io/hassio-addons/debian-base/amd64:7.7.1
 
-# https://hub.docker.com/_/alpine
-FROM alpine:3.16.2 as build_rtlamr
+# https://hub.docker.com/_/golang
+FROM golang:1.24.0-alpine3.21 as build_rtlamr
 # https://github.com/bemasher/rtlamr/releases
-ENV RTLAMR_VERSION 0.9.1
+ENV RTLAMR_VERSION 0.9.4
 
+RUN go install
 RUN set -eux; \
-    apk update; \
-        apk add --no-cache --virtual .build-deps \
-            tar=1.34-r0 \
-            curl=7.83.1-r2 \
-        ; \
-    APKARCH="$(apk --print-arch)"; \
-    case "${APKARCH}" in \
-        x86_64)  BINARCH='amd64' ;; \
-        armhf)   BINARCH='arm' ;; \
-        armv7)   BINARCH='arm' ;; \
-        aarch64) BINARCH='arm64' ;; \
-        *) echo >&2 "error: unsupported architecture (${APKARCH})"; exit 1 ;; \
-    esac; \
-    curl -J -L -o /tmp/rtlamr.tar.gz \
-    "https://github.com/bemasher/rtlamr/releases/download/v${RTLAMR_VERSION}/rtlamr_linux_${BINARCH}.tar.gz"; \
-    tar -xf /tmp/rtlamr.tar.gz -C /usr/bin; \
-    chmod a+x /usr/bin/rtlamr; \
-    rm /tmp/rtlamr.tar.gz;
+    go install "github.com/bemasher/rtlamr@v${RTLAMR_VERSION}"
+    mv ./bin/rtlamr /usr/bin/rtlamr
 
 # https://github.com/hassio-addons/addon-debian-base/releases
 # hadolint ignore=DL3006
@@ -31,19 +16,18 @@ FROM ${BUILD_FROM}
 
 RUN set -eux; \
     apt-get update; \
-    apt-get install -qy --no-install-recommends \ 
-        ca-certificates=20210119 \
-        librtlsdr-dev=0.6.0-3 \
-        python3-paho-mqtt=1.5.1-1 \
-        python3-dateutil=2.8.1-6 \
-        rtl-sdr=0.6.0-3 \
+    apt-get install -qy --no-install-recommends \
+        ca-certificates \
+        librtlsdr-dev \
+        python3-paho-mqtt \
+        python3-dateutil \
+        rtl-sdr \
         ; \
-    update-ca-certificates; \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*; \
     \
     echo "Add user for AMR2MQTT"; \
     mkdir -p /data/amr2mqtt; \
-    useradd -u 12345 -U -d /data/amr2mqtt abc; 
+    useradd -u 12345 -U -d /data/amr2mqtt abc;
 
 # Add rtlamr
 COPY --from=build_rtlamr /usr/bin/rtlamr /usr/bin/rtlamr

--- a/amr2mqtt/Dockerfile
+++ b/amr2mqtt/Dockerfile
@@ -1,30 +1,14 @@
-ARG BUILD_FROM=ghcr.io/hassio-addons/debian-base/amd64:6.2.7 
+ARG BUILD_FROM=ghcr.io/hassio-addons/debian-base/amd64:7.7.1
 
 # https://hub.docker.com/_/golang
-FROM golang:1.24.0-alpine3.21 as build_rtlamr
+FROM golang:1.24.0-alpine3.21 AS build_rtlamr
 # https://github.com/bemasher/rtlamr/releases
-ENV RTLAMR_VERSION 0.9.4
-
-RUN go install
+ENV RTLAMR_VERSION=0.9.4
+ENV GOBIN=/usr/bin
 RUN set -eux; \
-    apk update; \
-        apk add --no-cache --virtual .build-deps \
-            tar=1.34-r1 \
-            curl=8.5.0-r0 \
-        ; \
-    APKARCH="$(apk --print-arch)"; \
-    case "${APKARCH}" in \
-        x86_64)  BINARCH='amd64' ;; \
-        armhf)   BINARCH='arm' ;; \
-        armv7)   BINARCH='arm' ;; \
-        aarch64) BINARCH='arm64' ;; \
-        *) echo >&2 "error: unsupported architecture (${APKARCH})"; exit 1 ;; \
-    esac; \
-    curl -J -L -o /tmp/rtlamr.tar.gz \
-    "https://github.com/bemasher/rtlamr/releases/download/v${RTLAMR_VERSION}/rtlamr_linux_${BINARCH}.tar.gz"; \
-    tar -xf /tmp/rtlamr.tar.gz -C /usr/bin; \
-    chmod a+x /usr/bin/rtlamr; \
-    rm /tmp/rtlamr.tar.gz;
+    go install "github.com/bemasher/rtlamr@v${RTLAMR_VERSION}"; \
+    rtlamr --version
+
 
 # https://github.com/hassio-addons/addon-debian-base/releases
 # hadolint ignore=DL3006
@@ -83,4 +67,4 @@ LABEL \
     org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
     org.opencontainers.image.created=${BUILD_DATE} \
     org.opencontainers.image.revision=${BUILD_REF} \
-    org.opencontainers.image.version=${BUILD_VERSION}
+    org.opencontainers.image.version=${BUILD_VERSION} \

--- a/amr2mqtt/Dockerfile
+++ b/amr2mqtt/Dockerfile
@@ -1,7 +1,7 @@
-ARG BUILD_FROM=ghcr.io/hassio-addons/debian-base/amd64:7.7.1
+ARG BUILD_FROM=ghcr.io/hassio-addons/debian-base/amd64:7.8.3
 
 # https://hub.docker.com/_/golang
-FROM golang:1.24.0-alpine3.21 AS build_rtlamr
+FROM golang:1.24.5-alpine3.22 AS build_rtlamr
 # https://github.com/bemasher/rtlamr/releases
 ENV RTLAMR_VERSION=0.9.4
 ENV GOBIN=/usr/bin

--- a/amr2mqtt/build.yaml
+++ b/amr2mqtt/build.yaml
@@ -1,9 +1,5 @@
 ---
 build_from:
-  amd64: ghcr.io/hassio-addons/debian-base/amd64:7.7.1
-  armhf: ghcr.io/hassio-addons/debian-base/armhf:7.7.1
-  armv7: ghcr.io/hassio-addons/debian-base/armv7:7.7.1
-  aarch64: ghcr.io/hassio-addons/debian-base/aarch64:7.7.1
-codenotary:
-  base_image: codenotary@frenck.dev
-  signer: codenotary@degatano.com
+  amd64: ghcr.io/hassio-addons/debian-base/amd64:7.8.3
+  armv7: ghcr.io/hassio-addons/debian-base/armv7:7.8.3
+  aarch64: ghcr.io/hassio-addons/debian-base/aarch64:7.8.3

--- a/amr2mqtt/build.yaml
+++ b/amr2mqtt/build.yaml
@@ -1,9 +1,9 @@
 ---
 build_from:
-  amd64: ghcr.io/hassio-addons/debian-base/amd64:6.1.1
-  armhf: ghcr.io/hassio-addons/debian-base/armhf:6.1.1
-  armv7: ghcr.io/hassio-addons/debian-base/armv7:6.1.1
-  aarch64: ghcr.io/hassio-addons/debian-base/aarch64:6.1.1
+  amd64: ghcr.io/hassio-addons/debian-base/amd64:7.7.1
+  armhf: ghcr.io/hassio-addons/debian-base/armhf:7.7.1
+  armv7: ghcr.io/hassio-addons/debian-base/armv7:7.7.1
+  aarch64: ghcr.io/hassio-addons/debian-base/aarch64:7.7.1
 codenotary:
   base_image: codenotary@frenck.dev
   signer: codenotary@degatano.com


### PR DESCRIPTION
Tested as working on:

Add-on: AMR2MQTT
 AMR2MQTT for Home Assistant
-----------------------------------------------------------
 Add-on version: dev
 You are running the latest version of this add-on.
 System: Home Assistant OS 16.0  (aarch64 / raspberrypi5-64)
 Home Assistant Core: 2025.7.1
 Home Assistant Supervisor: 2025.07.1