### PR TITLE
Potential fix for code scanning alert no. 17: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -29,6 +29,9 @@ on:
         required: false
         default: ""
 
+permissions:
+  contents: read
+
 jobs:
   information:
     if: |


### PR DESCRIPTION
Potential fix for [https://github.com/Alvarofg/addon-amr2mqtt/security/code-scanning/17](https://github.com/Alvarofg/addon-amr2mqtt/security/code-scanning/17)

In general, the fix is to add an explicit `permissions` block either at the top level of the workflow (to apply to all jobs) or individually per job, granting only the minimum scopes needed. Since this workflow doesn’t appear to use `GITHUB_TOKEN` for write operations (it uses `DISPATCH_TOKEN` and `GHCR_TOKEN` secrets instead), we can safely restrict `GITHUB_TOKEN` to read‑only access to repository contents, which aligns with the recommendation (`contents: read`).

The single best minimal fix without changing functionality is to add a root‑level `permissions` block right after the `on:` section (or just before `jobs:`) that sets `contents: read`. This will apply to `information`, `deploy`, `publish-edge`, and `publish-stable` jobs uniformly, limiting `GITHUB_TOKEN` while keeping all current behavior (Docker pushes continue using `GHCR_TOKEN`, and repository dispatch continues using `DISPATCH_TOKEN`). No additional imports, methods, or definitions are needed.

Concretely, in `.github/workflows/deploy.yaml`, insert:

```yaml
permissions:
  contents: read
```

at the workflow root (same indentation as `on:` and `jobs:`), e.g. between the `workflow_dispatch` block and `jobs:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
