### PR TITLE
Potential fix for code scanning alert no. 13: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,7 @@
 ---
 name: CI
+permissions:
+  contents: read
 
 # yamllint disable-line rule:truthy
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/Alvarofg/addon-amr2mqtt/security/code-scanning/13](https://github.com/Alvarofg/addon-amr2mqtt/security/code-scanning/13)

In general, fix this by explicitly declaring a `permissions:` block that grants only the minimal required scopes. For a CI workflow that just checks out code and runs linters and builds, `contents: read` is usually sufficient; additional scopes (like `pull-requests: write`) should only be added if some job needs to post comments or modify PRs.

The single best fix here, without changing existing functionality, is to add a `permissions:` block at the top level of `.github/workflows/ci.yaml`, right under `name: CI`. This will apply to all jobs that don’t define their own `permissions`, including `lint-yamllint`. Since the shown jobs only read repository contents and, in one case, pass `GITHUB_TOKEN` to Prettier (but not for any write operation we can see), setting `contents: read` is an appropriate minimal starting point and matches the CodeQL recommendation. No imports or additional methods are needed; it’s a pure YAML configuration change.

Concretely:
- Edit `.github/workflows/ci.yaml`.
- Insert:

  ```yaml
  permissions:
    contents: read
  ```

  after the `name: CI` line (line 2 in the snippet).  
- Leave all job definitions unchanged; they will inherit this read-only `GITHUB_TOKEN` permission.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
