### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr-labels.yaml
+++ b/.github/workflows/pr-labels.yaml
@@ -10,6 +10,10 @@ on:
       - unlabeled
       - synchronize
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   workflows:
     uses: mdegat01/addon-workflows/.github/workflows/pr-labels.yaml@main


### PR DESCRIPTION
Potential fix for [https://github.com/Alvarofg/addon-amr2mqtt/security/code-scanning/7](https://github.com/Alvarofg/addon-amr2mqtt/security/code-scanning/7)

To fix the problem, add an explicit `permissions:` block to this workflow, granting only the minimal scopes required. Since this file simply delegates to a reusable workflow for pull request label management, it most likely needs only read access to repository contents and read access to pull request metadata. A safe minimal baseline that aligns with GitHub guidance is `contents: read`. If the reusable workflow needs to write to pull requests (e.g., add labels, comments), you can additionally allow `pull-requests: write`. We cannot inspect the reusable workflow here, but to keep the fix minimal and safe while still supporting typical PR‑label workflows, we’ll set `contents: read` and `pull-requests: write`.

Concretely, edit `.github/workflows/pr-labels.yaml` to insert a `permissions:` block at the root level, between the `on:` section and `jobs:`. No imports or additional files are needed; GitHub Actions interprets the `permissions` key natively. This change does not alter the job definition or its behavior; it only restricts the default `GITHUB_TOKEN` privileges.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
