### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -9,4 +9,8 @@ on:
 
 jobs:
   workflows:
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
     uses: mdegat01/addon-workflows/.github/workflows/stale.yaml@main


### PR DESCRIPTION
Potential fix for [https://github.com/Alvarofg/addon-amr2mqtt/security/code-scanning/5](https://github.com/Alvarofg/addon-amr2mqtt/security/code-scanning/5)

In general, fix this by explicitly specifying a `permissions` block either at the root of the workflow (applied to all jobs) or under the specific job definition. For reusable workflows, GitHub supports setting `permissions` on the calling job; these become the default for the called workflow unless it overrides them. The minimal safe baseline for most workflows that only need to read repository contents is `contents: read`.

For this specific file, the best fix with minimal behavioral change is to add a restrictive `permissions` block to the `workflows` job that calls the reusable stale workflow. Since a stale bot usually only needs to read repository contents and interact with issues and/or pull requests, declare read access for contents and write access only for the resources it must modify. A conservative and common configuration for a stale workflow is:
- `contents: read` (to read repo data),
- `issues: write` (to comment/label/close issues),
- `pull-requests: write` (to comment/label/close PRs).

Concretely, in `.github/workflows/stale.yaml`, under `jobs:`, within the `workflows:` job and before the `uses:` line, add a `permissions:` block with these keys. No imports or additional definitions are needed because this is a YAML configuration file for GitHub Actions, not executable code.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
