### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lock.yaml
+++ b/.github/workflows/lock.yaml
@@ -9,4 +9,6 @@ on:
 
 jobs:
   workflows:
+    permissions:
+      contents: read
     uses: mdegat01/addon-workflows/.github/workflows/lock.yaml@main


### PR DESCRIPTION
Potential fix for [https://github.com/Alvarofg/addon-amr2mqtt/security/code-scanning/2](https://github.com/Alvarofg/addon-amr2mqtt/security/code-scanning/2)

In general, the fix is to explicitly declare `permissions` for the workflow or for the specific job that invokes the reusable workflow. Since this workflow only defines a single job that calls a remote reusable workflow, we can add a `permissions` block at the job level (`jobs.workflows.permissions`) so that the `GITHUB_TOKEN` passed to the reusable workflow is restricted. A conservative, minimal starting point consistent with GitHub’s recommendations is `contents: read`; if the reusable workflow requires more granular write permissions (for example, to lock issues or PRs), those could be added, but we cannot safely infer them from the snippet alone.

Concretely, in `.github/workflows/lock.yaml`, under `jobs: workflows:`, we add a `permissions:` mapping above the `uses:` line. This leaves existing functionality intact while constraining the default token. The change is small, self-contained, and does not require imports or external dependencies.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
